### PR TITLE
CASMPET-7176: SBPS Marshall Agent Key:Value mismatch to IMS Image

### DIFF
--- a/marshal/bin/agent.py
+++ b/marshal/bin/agent.py
@@ -71,7 +71,6 @@ def main():
     while True:
 
         logging.info("START SCAN")
-
         ## ----------------------------------------------------------
         ## Pre-flight for all types of image projection
         ## ----------------------------------------------------------        
@@ -243,7 +242,6 @@ def main():
             continue     
         
         logging.info(f"Counted {len(ims_images)} IMS images. Starting rootfs image reconciliation.")
-
         for ims_image in ims_images:
 
             # Retrieve the IMS manifest for the image and verify required attributes
@@ -274,7 +272,7 @@ def main():
             if rootfs_s3_path is None or rootfs_s3_etag is None:
                 logging.error(f"path or etag missing in IMS manifest -> {m}")
                 continue
-
+            
             if config.KV['IMS_TAGGING']:
 
                 # Check to see if image is marked for projection
@@ -282,9 +280,12 @@ def main():
                 # version of IMS in use doesn't support image tagging
 
                 if 'metadata' in ims_image.keys():
-                    if 'annotation' in ims_image['metadata'].keys():
+                    if 'sbps-project' not in ims_image['metadata'].keys():
+                        logging.info(f"No sbps-project key value, so image is not marked for projection")
+                        continue
+                    else:
                         try:
-                            if ims_image['metadata']['annotation']['sbps-project'] != "true":
+                            if ims_image['metadata']['sbps-project'] != "true":
                                 logging.info(f"Image is not marked for projection in IMS {m}")
                                 continue
                         except KeyError:

--- a/marshal/lib/config.py
+++ b/marshal/lib/config.py
@@ -26,7 +26,6 @@
 
 import os
 
-
 KV = dict()
 _env_prefix = 'SBPS_MARSHAL_'
 
@@ -52,14 +51,15 @@ else:
     KV['IMS_URI'] = 'apis/ims/v3/images'
 
 # Toggle to use IMS image tagging or not
-
+# Value is set True by default, need to revisit
 if os.environ.get(_env_prefix + 'IMS_TAGGING') is not None:
+    KV['IMS_TAGGING'] = os.environ.get(_env_prefix + 'IMS_TAGGING')
     if KV['IMS_TAGGING'] == "true":
         KV['IMS_TAGGING'] = True
     else:
         KV['IMS_TAGGING'] = False
 else:
-    KV['IMS_TAGGING'] = False
+    KV['IMS_TAGGING'] = True 
 
 # IMS request timeout to use (seconds)
 


### PR DESCRIPTION
## Summary and Scope

IMS tagging feature has introduced where IMS images can be tagged using craycli command with key/value pair of sbps/true. 
With this IMS images mainly rootfs images required for iSCSI based content projection can be marked for projection. This key/value pair has been introduced in the image metadata. The Marshal agent had little away from this metadata to check for images being marked for projection. So this is corrected now and images having key/valu pair of sbps/true, gets projected. 

## Issues and Related PRs

IMS tagging feature is available in fix for CASMCMS-8833

* Resolves [issue id](issue link): CASMPET-7176

### Tested on:

Tested on Starlord (CSM 1.6 alptha.54 with IMS patch having fix for CASMCMS-8833 ) and Surtur. 
Surtur had CSM 1.6.0-alpha.58

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? - TBD
- Were continuous integration tests run? If not, why? - TBD
- Was upgrade tested? If not, why? - TBD
- Was downgrade tested? If not, why? - TBD
- Were new tests (or test issues/Jiras) created for this change? - None

## Risks and Mitigations
None

## Pull Request Checklist

- [x ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
