### PR TITLE
- CASMPET-7196: Update SBPS Marshal Agent S3_CREDENTIAL_FILE

### DIFF
--- a/marshal/lib/config.py
+++ b/marshal/lib/config.py
@@ -87,7 +87,7 @@ else:
 if os.environ.get(_env_prefix + 'S3_CREDENTIAL_FILE') is not None:
     KV['S3_CREDENTIAL_FILE'] = os.environ.get(_env_prefix + 'S3_CREDENTIAL_FILE')
 else:
-    KV['S3_CREDENTIAL_FILE'] = '/root/.ims.s3fs'
+    KV['S3_CREDENTIAL_FILE'] = '/root/.iscsi-sbps.s3fs'
 
 # S3 bucket to use to verify Squashfs images
     


### PR DESCRIPTION
## Summary and Scope

Need to update SBPS Marshal Agent config for S3_CREDENTIAL_FILE in order to use new s3 user credentials of SBPS instead of default IMS credentials for mounting boot-images.

## Issues and Related PRs

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing
Bare metal: surtur

### Tested on:
Bare metal: surtur

### Test description:
Verified worker node personalization (CFS ansible plays) of iSCSI SBPS which also includes SBPS Marshal Agent install/ config. Verified mounting of boot-images with new s3 read only policy.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [NA] License file intact
- [x] Target branch correct
- [NA] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

