### PR TITLE
CASMPET-7225: Fallback to default IMS user policy for CPS

### DIFF
--- a/marshal/lib/config.py
+++ b/marshal/lib/config.py
@@ -87,7 +87,7 @@ else:
 if os.environ.get(_env_prefix + 'S3_CREDENTIAL_FILE') is not None:
     KV['S3_CREDENTIAL_FILE'] = os.environ.get(_env_prefix + 'S3_CREDENTIAL_FILE')
 else:
-    KV['S3_CREDENTIAL_FILE'] = '/root/.iscsi-sbps.s3fs'
+    KV['S3_CREDENTIAL_FILE'] = '/root/.ims.s3fs'
 
 # S3 bucket to use to verify Squashfs images
     


### PR DESCRIPTION
[CASMPET-7225](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7225)

## Summary and Scope
We must have writable access to "/var/lib/cps-local/boot-images" mount directory of "boot-images" bucket in order for CPS to function and also user need write access while removing cos-config-data under "/var/lib/cps-local/boot-images", when he wants to disable CPS.

When CPS is removed in USS-1.3, we can fallback again to this dedicated s3fs read-only policy and mount the boot-images bucket back again during personalization with this new policy.

## Issues and Related PRs

https://github.com/Cray-HPE/csm-config/pull/302

## Testing

bare metal surtur

### Tested on:

bare metal surtur

### Test description:
Verified sbps-marshal agent referring to earlier IMS s3 credential file for image mapping (from "boot-images" bucket) along with verification of node personalization with CFS plays (with disablement of s3fs mount of boot-images bucket with new read only policy (PR: https://github.com/Cray-HPE/csm-config/pull/302) and observed that it fallback to default IMS user policy for image mapping and s3fs mount of "boot-images" bucket.

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [NA] License file intact
- [x] Target branch correct
- [NA ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
