### PR TITLE
CASMPET-7238: /etc/target/saveconfig.json exists as a dir instead of file

### DIFF
--- a/marshal/bin/agent.py
+++ b/marshal/bin/agent.py
@@ -38,7 +38,7 @@ import lib.s3 as s3
 import lib.ims as ims
 import lib.lio as lio
 import subprocess
-
+import shutil
 
 def main():
 
@@ -112,6 +112,13 @@ def main():
         if os.path.isfile(config.KV['LIO_SAVE_FILE']):
             with open(config.KV['LIO_SAVE_FILE'], 'r') as f:
                 lio_save = json.load(f)
+        elif os.path.isdir(config.KV['LIO_SAVE_FILE']):
+            if os.path.isfile('/etc/target/saveconfig.json/saveconfig.json.temp'):
+                shutil.move('/etc/target/saveconfig.json/saveconfig.json.temp', '/etc/target/')
+                os.rmdir('/etc/target/saveconfig.json/')
+                os.rename('/etc/target/saveconfig.json.temp', '/etc/target/saveconfig.json')
+                with open('/etc/target/saveconfig.json', 'r') as f:
+                    lio_save = json.load(f)
         else:
             logging.error(f"LIO Save file does not exist at {config.KV['LIO_SAVE_FILE']}, aborting")
             time.sleep(config.KV['SCAN_FREQUENCY'])


### PR DESCRIPTION
## Summary and Scope

The iscsi configuration is saved in /etc/target/saveconfig.json. But on some systems this exists as directory and actual file is inside this directory as /etc/target/saveconfig.json/saveconfig.json.temp Hence this case needs to handled in SBPS Marshal agent, else SBPS Marshal agent will fail. This code fix is addressing this issue.

## Issues and Related PRs
None.

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link): - CASMPET-7238
* Change will also be needed in `<insert branch name here>`: N/A
* Future work required by [issue id](issue link):  N/A 
* Documentation changes required in [issue id](issue link): N/A 
* Merge with/before/after `<insert PR URL here>`: N/A

## Testing
Tested on Starlord where 1.6.0-alpha.67 was installed and issue was reproduced. 

### Tested on:
Starlord. 
 
### Test description:

The issue was reproduced on w002 and w003 of starlord where /etc/target/saveconfig.json existed as directory instead of file. So after applying the code fix. Restarted the SBPS marshal agent (systemd service), then Marshal agent successfuly ran fine. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?: yes
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?: TBD
- Was downgrade tested? If not, why?: N/A 
- Were new tests (or test issues/Jiras) created for this change?; No

## Risks and Mitigations
None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
