### PR TITLE
CASMTRIAGE-7373: SBPS is adding spire hard link in /usr/bin rather th…

### DIFF
--- a/marshal/lib/config.py
+++ b/marshal/lib/config.py
@@ -108,7 +108,7 @@ else:
 if os.environ.get(_env_prefix + 'SPIRE_AGENT_PATH') is not None:
     KV['SPIRE_AGENT_PATH'] = os.environ.get(_env_prefix + 'SPIRE_AGENT_PATH')
 else:
-    KV['SPIRE_AGENT_PATH'] = '/usr/bin/sbps-marshal-spire-agent'
+    KV['SPIRE_AGENT_PATH'] = '/opt/cray/cray-spire/sbps-marshal-spire-agent'
 
 # The Spire JWT Audience to use
 


### PR DESCRIPTION
…an /opt/cray

  - updated spire agent hard link path for SBPS

## Summary and Scope
As per the guidelines/ request (original SKERN-7109 and this new CASMTRIAGE-7373), Spire workload (exec) paths, configuration, and data should not be user accessible. In this regard need to move hard link of spire-agent for new iSCSI SBPS from "/usr/bin/" to new "/opt/cray/cray-spire/" directory. The current change looks to be proposed/ added earlier under "/usr/bin/" for user access. 

Fixed to update the spire-agent hard link path reference from "/usr/bin/sbps-marshal-spire-agent" to "/opt/cray/cray-spire/sbps-marshal-spire-agent" in sbps-marshal agent code. The actual hard link creation of this path is in csm-config ansible plays of SBPS (please refer "Dependency PR" below).

## Issues and Related PRs

Dependency PR:  https://github.com/Cray-HPE/csm-config/pull/308

## Testing

Tested on bare metal system surtur.

### Tested on:

Tested on bare metal system surtur.

### Test description:

Tested the change with worker node personalization for iSCSI SBPS. Observed that play books have been successful and new spire-agent hard link "/opt/cray/cray-spire/sbps-marshal-spire-agent" has been created and referred by marshal-agent systemd service. Also see that the "sbps-marshal" agent systemd service is successfully running without any errors.
## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [NA] License file intact
- [x] Target branch correct
- [NA] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

