### PR TITLE
Added text/script to restart goss-servers on all worker nodes

### DIFF
--- a/GOSS_tests_for_sbps.md
+++ b/GOSS_tests_for_sbps.md
@@ -35,6 +35,7 @@ Expected output:
 Due to this goss tests were not run. Run below from master node to restart 'goss-servers' on all worker nodes at one go:
 
      worker_nodes=$(grep -oP "(ncn-w\d+)" /etc/hosts | sort -u | tr -t '\n' ',')
+     worker_nodes=${worker_nodes%,}
      pdsh -S -b -w $worker_nodes 'systemctl restart goss-servers'
 
 Two ways to run the goss tests:

--- a/GOSS_tests_for_sbps.md
+++ b/GOSS_tests_for_sbps.md
@@ -31,6 +31,12 @@ Expected output:
         Tasks: 682
         CGroup: /system.slice/goss-servers.service
 
+**Note:** In CSM 1.6.0, it is required to restart 'goss-servers' service as the 'goss-servers' is not getting restarted after the upgrade.
+Run below from master node to restart 'goss-servers' on all worker nodes:
+
+     worker_nodes=$(grep -oP "(ncn-w\d+)" /etc/hosts | sort -u | tr -t '\n' ',')
+     pdsh -S -b -w $worker_nodes 'systemctl restart goss-servers'
+
 Two ways to run the goss tests:
 
 Method #1: Run the below script from master/pit node

--- a/GOSS_tests_for_sbps.md
+++ b/GOSS_tests_for_sbps.md
@@ -32,7 +32,7 @@ Expected output:
         CGroup: /system.slice/goss-servers.service
 
 **Note:** In CSM 1.6.0, it is required to restart 'goss-servers' service as the 'goss-servers' is not getting restarted after the upgrade.
-Due to this goss tests were not run. Run below from master to restart 'goss-servers' on all worker nodes at one go:
+Due to this goss tests were not run. Run below from master node to restart 'goss-servers' on all worker nodes at one go:
 
      worker_nodes=$(grep -oP "(ncn-w\d+)" /etc/hosts | sort -u | tr -t '\n' ',')
      pdsh -S -b -w $worker_nodes 'systemctl restart goss-servers'

--- a/GOSS_tests_for_sbps.md
+++ b/GOSS_tests_for_sbps.md
@@ -32,7 +32,7 @@ Expected output:
         CGroup: /system.slice/goss-servers.service
 
 **Note:** In CSM 1.6.0, it is required to restart 'goss-servers' service as the 'goss-servers' is not getting restarted after the upgrade.
-Run below from master node to restart 'goss-servers' on all worker nodes:
+Due to this goss tests were not run. Run below from master to restart 'goss-servers' on all worker nodes at one go:
 
      worker_nodes=$(grep -oP "(ncn-w\d+)" /etc/hosts | sort -u | tr -t '\n' ',')
      pdsh -S -b -w $worker_nodes 'systemctl restart goss-servers'


### PR DESCRIPTION
## Summary and Scope

Added documentation to restart the 'goss-servers' in CSM 1.6.0 as its not restarted after the upgrade from CSM 1.5 to CSM 1.6.0 due to bug CASMPET-7263. Without restarting 'goss-servers', goss tests are not run as the host names are not matched correctly. 

## Issues and Related PRs

CASMPET-7263, CASMPET-7261

* Resolves [issue id](issue link): CASMTRIAGE-7426
* Change will also be needed in `<insert branch name here>`: N/A 
* Future work required by [issue id](issue link): N/A 
* Documentation changes required in [issue id](issue link): CASMTRIAGE-7426
* Merge with/before/after `<insert PR URL here>`: N/A 

## Testing
Tested the script provided to restart the 'goss-servers' systemd service on all the worker nodes at one go on Fanta system. It looked fine. 

### Tested on:
Fanta 

### Test description:
As this is documentation no testing required. Tested the script to restart 'goss-servers' on all the worker nodes on Fanta. 

## Risks and Mitigations
N/A 

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
