### PR TITLE
CASMTRIAGE-7489: iSCSI SBPS boot projection failed with the rootfs

### DIFF
--- a/etc/sbps-marshal.service
+++ b/etc/sbps-marshal.service
@@ -6,6 +6,8 @@ After=multi-user.target
 [Service]
 Type=simple
 ExecStart=/usr/lib/sbps-marshal/bin/sbps-marshal
+Restart=on-failure
+RestartSec=180s
 
 [Install]
 WantedBy=multi-user.target

--- a/marshal/bin/agent.py
+++ b/marshal/bin/agent.py
@@ -263,7 +263,9 @@ def main():
             rootfs_s3_etag = None
 
             for artifact in manifest["artifacts"]:
-                if artifact["type"] == "application/vnd.cray.image.rootfs.squashfs":
+                if artifact["type"] == "application/vnd.cray.image.rootfs.squashfs" and \
+                    'link' in artifact and artifact['link'] is not None and \
+                    'path' in artifact['link'] and 'etag' in artifact['link']:
                     # Expects a normalized s3 path for link->path, e.g., 
                     # s3://boot-images/00d18ed1-20a3-4df2-affb-a88fda00b6f6/rootfs
                     rootfs_s3_path = artifact["link"]["path"]


### PR DESCRIPTION
## Summary and Scope

iSCSI SBPS boot projection failed with the rootfs images having 'etag' missing. The SBPS Marshal agent is fixed to handle 
error cases with respect to rootfs image artifact having invalid values.

## Issues and Related PRs

* Resolves [issue id](issue link): https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7489

## Testing

Odin Baremetal

### Tested on:

Odin Baremetal system

### Test description:

Applied the fix on odin (w001) and restarted sbps-marshal.service. With this we see that SBPS Marshal service is not crashing and reporting the error message for the missing etag image appropriately.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? goss tests were run.
- Were continuous integration tests run? If not, why?: N/A 
- Was upgrade tested? If not, why?: N/A 
- Was downgrade tested? If not, why?: N/A 
- Were new tests (or test issues/Jiras) created for this change?: NO

## Risks and Mitigations
None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [NA] License file intact
- [x] Target branch correct
- [NA ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [NA ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

