### PR TITLE
Casmtriage 7559 fix

### DIFF
--- a/marshal/bin/agent.py
+++ b/marshal/bin/agent.py
@@ -193,7 +193,6 @@ def main():
                     if fileio_backstore["name"] == pe_product:
                         if fileio_backstore["wwn"] == pe_wwn:
                             found_backstore = lio.fileio_size(fileio_backstore, size)        
-                            logging.info(f"Asha: found_backstore for PE = {found_backstore}")
 
             if found_backstore:
                 continue # backstore already exists, assume LUN does as well
@@ -330,14 +329,12 @@ def main():
             # dev == s3fspath, name == product, wwn == wwn
 
             size_r = s3_object['Size']
-            logging.info(f"Asha: rootfs image synchronisation s3_object size = {size_r}") 
             found_backstore = False
             for fileio_backstore in fileio_backstores:
                 if fileio_backstore["dev"] == s3fs_path:
                     if fileio_backstore["name"] == rootfs_product:
                         if fileio_backstore["wwn"] ==rootfs_wwn:
                             found_backstore = lio.fileio_size(fileio_backstore, size_r)
-                            logging.info(f"Asha: found_backstore for PE = {found_backstore}")
 
             ## TODO: should we guard against other S3FS corner cases here, like transient cache state? 
 
@@ -384,25 +381,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-def fileio_size(product: str, size: int):
-
-    if product["size"] == size:
-        logging.info(f"Asha:lio: fileio_backstore size = {product["size"]} and s3_object size = {size}")
-        found_backstore = True
-
-    else:
-        try:
-            logging.info(f"Asha:lio: fileio_backstore size = {product["size"]} and s3_object size = {size}")
-            lio.delete_fileio_backstore(product["name"])
-        except Exception as err:
-            logging.error(
-                f"Unable to remove LIO fileio backstore for {product["dev"]}, received -> {str(err)}")
-
-        try:
-            lio.save_config()
-        except Exception as err:
-            logging.error(f"Unable to save LIO configuration, received -> {str(err)}")
-
-        return found_backstore
-

--- a/marshal/lib/lio.py
+++ b/marshal/lib/lio.py
@@ -26,6 +26,7 @@
 
 import hashlib
 import subprocess
+import logging
 
 import lib.config as config
 
@@ -126,3 +127,25 @@ def save_config():
 
     ctx = f"saveconfig"
     subprocess.run([config.KV['TARGETCLI_BIN'], ctx], check=True)
+
+def fileio_size(product: str, size: int):
+   
+    if product["size"] == size:
+        logging.info(f"Asha:lio: fileio_backstore size = {product["size"]} and s3_object size = {size}")
+        found_backstore = True
+
+    else:
+        try:
+            logging.info(f"Asha:lio: fileio_backstore size = {product["size"]} and s3_object size = {size}")
+            #found_backstore = False
+            delete_fileio_backstore(product["name"])
+        except Exception as err:
+            logging.error(
+                f"Unable to remove LIO fileio backstore for {product["dev"]}, received -> {str(err)}")
+        
+        try:
+            save_config()
+        except Exception as err:
+            logging.error(f"Unable to save LIO configuration, received -> {str(err)}")
+
+    return found_backstore

--- a/marshal/lib/lio.py
+++ b/marshal/lib/lio.py
@@ -131,13 +131,10 @@ def save_config():
 def fileio_size(product: str, size: int):
    
     if product["size"] == size:
-        logging.info(f"Asha:lio: fileio_backstore size = {product["size"]} and s3_object size = {size}")
         found_backstore = True
 
     else:
         try:
-            logging.info(f"Asha:lio: fileio_backstore size = {product["size"]} and s3_object size = {size}")
-            #found_backstore = False
             delete_fileio_backstore(product["name"])
         except Exception as err:
             logging.error(


### PR DESCRIPTION
## Summary and Scope

'Targetcli ls' command lists initial size of zero bytes as the size of the image if the image uploaded is new. Doesn't report the updated/final size once the image upload is complete.

## Issues and Related PRs

* Resolves [issue id](issue link): CASMTRIAGE-7559

## Testing
Tested on Fanta having CSM 1.6.0-rc.6

### Tested on:
Fanta

### Test description:
Unit test results are uploaded in the Jira CASMTRIAGE-7559. Testing is done by uploading a 20 PE images sequentially and running 'targetcli ls' on the worker node. With the fix the image is listed appropriately.  Need to test the same with rootfs images.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?: N/A
- Were continuous integration tests run? If not, why?: N/A 
- Was upgrade tested? If not, why?: N/A 
- Was downgrade tested? If not, why?: N/A 
- Were new tests (or test issues/Jiras) created for this change?: N/A

## Risks and Mitigations
None.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
