### PR TITLE
CASMTRIAGE-7910: Added xname validation for spire authentication

### DIFF
--- a/marshal/lib/auth.py
+++ b/marshal/lib/auth.py
@@ -27,9 +27,8 @@
 import json
 import os
 import subprocess
-
+import logging
 import lib.config as config
-
 
 def get_s3fs_creds(file_path: str) -> tuple:
 
@@ -63,10 +62,17 @@ def get_spire_svid_jwt() -> str:
     p = subprocess.run(ctx, check=True, capture_output=True)
 
     entries = json.loads(p.stdout)
+
+    file = open("/etc/cray/xname", "r")
+    xname = file.read().rstrip() 
+    file.close()
+
     for e in entries:
         if 'svids' in e.keys():
             for svid in e['svids']:
                 if svid['spiffe_id'] == "spiffe://shasta/ncn/workload/sbps-marshal":
                     return svid['svid']
-    
+                if svid['spiffe_id'] == f"spiffe://shasta/ncn/{xname}/workload/sbps-marshal":
+                    return svid['svid']
+ 
     raise ValueError("Could not find valid SVID")

--- a/marshal/lib/auth.py
+++ b/marshal/lib/auth.py
@@ -27,7 +27,7 @@
 import json
 import os
 import subprocess
-import logging
+
 import lib.config as config
 
 def get_s3fs_creds(file_path: str) -> tuple:


### PR DESCRIPTION
## Summary and Scope
sbps-marshal agent (systemctl service) was not projecting images from IMS as it failed due to not finding valid SVID. This is due to CASMTRIAGE-7901 where sbps-marshal workload was not having with XNAME validation. 

## Issues and Related PRs
CASMTRIAGE-7901
https://github.com/Cray-HPE/docs-csm/pull/5777
Spire 1.6: https://github.com/Cray-HPE/cray-spire/pull/108
Spire 1.7: https://github.com/Cray-HPE/cray-spire/pull/107
CSM 1.6: https://github.com/Cray-HPE/csm/pull/3975

* Resolves [issue id](issue link): https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7910
* Change will also be needed in `<insert branch name here>`: N/A
* Future work required by [issue id](issue link): N/A
* Documentation changes required in [issue id](issue link): N/A
* Merge with/before/after `<insert PR URL here>`: N/A

## Testing
Lemondrop

### Tested on:
Lemondrop having 1.6.1-rc.6 where xname validation was turned on and fix for CASMTRIAGE-7901 was applied.

### Test description:
Apply the changes  and restarted the sbps-marshal agent. It ran successfully.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?: yes
- Were continuous integration tests run? If not, why?: N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why?: N/A
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [NA] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [NA ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

