### PR TITLE
CASMTRIAGE-8171: Worker node hung due to flood of NON_EXISTENT_LUN me…

### DIFF
--- a/marshal/bin/agent.py
+++ b/marshal/bin/agent.py
@@ -69,6 +69,9 @@ def main():
         logging.error(f"hostname retrieval failed, exiting..")
         sys.exit(1)
 
+    # Retrieving IQN as /etc/target/saveconfig.son will not exist initially
+    IQN = f'iqn.2023-06.csm.iscsi:{hostname}'
+
     ## --------------------------------------------------------------
     ## Main Agent Loop
     ## --------------------------------------------------------------
@@ -90,14 +93,9 @@ def main():
                 logging.info(f"Target service is not active, starting")
                 subprocess.run(["systemctl", "start", "target.service"], check=True)
         else:
-            logging.info(f"Node does not have iSCSI label, stopping the target service")
+            logging.info(f"Node does not have iSCSI label, disabling the target port")
 
-            tgt_status, _ = run_command("systemctl is-active target.service")
-
-            if tgt_status == "active":
-                logging.info(f"Target service is active, stopping it")
-                subprocess.run(["systemctl", "stop", "target.service"], check=True)
-
+            lio.disable_target(IQN)
             time.sleep(config.KV['SCAN_FREQUENCY'])
             continue
 
@@ -406,6 +404,13 @@ def main():
                     logging.error(f"Unable to save LIO configuration, received -> {str(err)}")
 
         logging.info("END SCAN")
+
+        tgtp_status = lio.get_tgtp_status(target_iqn)
+
+        if tgtp_status != 'True':
+            logging.info(f"Target port is disabled, enabling the same")
+            lio.enable_target(target_iqn)
+
         time.sleep(config.KV['SCAN_FREQUENCY'])
 
 def run_command(cmd):

--- a/marshal/lib/lio.py
+++ b/marshal/lib/lio.py
@@ -1,7 +1,7 @@
 #
 #  MIT License
 #
-#  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+#  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a
 #  copy of this software and associated documentation files (the "Software"),
@@ -147,3 +147,34 @@ def fileio_size(product: str, size: int):
             logging.error(f"Unable to save LIO configuration, received -> {str(err)}")
 
     return found_backstore
+
+def disable_target(iqn: str):
+
+    ctx = f"/iscsi/{iqn}/tpg1 disable"
+    subprocess.run([config.KV['TARGETCLI_BIN'], ctx], check=True)
+
+def enable_target(iqn: str):
+
+    ctx = f"/iscsi/{iqn}/tpg1 enable"
+    subprocess.run([config.KV['TARGETCLI_BIN'], ctx], check=True)
+
+def get_tgtp_status(iqn: str):
+
+    try:
+        # Run the targetcli info command and capture output
+        cmd = f"targetcli /iscsi/{iqn}/tpg1 info"
+
+        result = subprocess.run(cmd, shell=True, check=True,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        # Extract the status (second word of first line)
+        output = result.stdout.decode('utf-8').strip()
+        if output:
+            first_line = output.splitlines()[0]
+            tgt_status = first_line.split()[1]
+        return tgt_status
+
+    except subprocess.CalledProcessError as e:
+        logging.error(f"Error running targetcli: {e.stderr}")
+        return None
+


### PR DESCRIPTION
…ssages with rebuild of the node.

## Summary and Scope

Worker node hung in rebuild scenario due to flood of NON_EXISTENT_LUN messages.
- The fix is spread across iSCSI ansible playbooks in 'csm-config' repo and SBPS Marshal agent
- Added support to disable/enable iSCSI target port based on iSCSI label unset/set on onthe worker node

## Issues and Related PRs
https://github.com/Cray-HPE/csm-config/pull/370

* Resolves [issue id](issue link): CASMTRIAGE-8171
* Change will also be needed in `<insert branch name here>`: N/A
* Future work required by [issue id](issue link): N/A 
* Documentation changes required in [issue id](issue link): N/A 
* Merge with/before/after `<insert PR URL here>`: N/A 

## Testing
Unit test results are attached with Jira [CASMTRIAGE-8171-Unit-test.txt]

### Tested on:
Lemondrop having CSM 1.6.1-rc.7 is installed.

### Test description:
Unit test results attached with the Jira has all the details and snippets.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?: Yes
- Were continuous integration tests run? If not, why?: N/A
- Was upgrade tested? If not, why?: TBD
- Was downgrade tested? If not, why?: N/A 
- Were new tests (or test issues/Jiras) created for this change?: No

## Risks and Mitigations
None.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [NA] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable