### PR TITLE
CASMTRIAGE-8999: Recurrence of LUN assigments messages seen in comput…

### DIFF
--- a/marshal/bin/agent.py
+++ b/marshal/bin/agent.py
@@ -404,15 +404,12 @@ def main():
 
         logging.info("END SCAN")
 
-        lio.first_scan_complete = True
+        lio.load_state()
 
-        tgtp_status = lio.get_tgtp_status(target_iqn)
-        if tgtp_status != 'True':
-            logging.info(f"Target port is disabled, enabling the same")
-            lio.enable_target(target_iqn)
-
-        # Restart the target service only once after the 1st SCAN
-        if lio.first_scan_complete and not lio.tgt_restart_done:
+        # Restart the target service only once after the first SCAN is complete
+        if not lio.state["initialized"]:
+            # one-time initialization
+            logging.info(f"Restart target.service")
             lio.tgt_service_restart()
 
         time.sleep(config.KV['SCAN_FREQUENCY'])


### PR DESCRIPTION
## Summary and Scope

**Background**

As part of the fix for [CASMTRIAGE-8984](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8984), global variables were introduced in the _sbps-marshal_ agent to ensure that the _target.service_ is restarted exactly once after the first SCAN completes. This was especially required in worker node rebuild scenarios, where existing configuration and data are wiped, and a restart of _target.service_ is necessary to apply the refreshed configuration.

This fix successfully resolved the original issue where, during a worker node rebuild, a previously faulty path on the compute node transitioned back to the active state once the rebuild completed, and _target.service_ was restarted by the sbps-marshal agent after the first SCAN.

**Issue Identified**

Looks like the global variables were reset continuously at every SCAN and as a result, the agent repeatedly interpreted each restart as a “first scan” scenario and _target.service_ was restarted every 180 seconds. This caused continuous SCSI path churn and repeated kernel messages on compute nodes, such as:

```
[Tue Jan 20 15:42:01 2026] [ T7157] sd 9:0:0:9: alua: supports implicit and explicit TPGS
[Tue Jan 20 15:42:01 2026] [ T7157] sd 9:0:0:9: alua: device naa.6001405c0754bcc7eea5054b2b41c273 port group 0 rel port 1
[Tue Jan 20 15:42:01 2026] [   C18] sd 9:0:0:9: LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN 
```

**Fix Implemented**

Replaced the in-memory global variables with a file-based status mechanism. The file persists across sbps-marshal agent restarts and reliably tracks whether the first _target.service_ restart has already occurred. The _target.service_ is now restarted exactly once after the first SCAN completion, even across marshal agent restarts. This results in preventing unnecessary periodic restarts of _target.service_ and eliminating repeated SCSI path change events and kernel log noise.

**Note:** Preserves the original behavior required for rebuild scenarios addressed in CASMTRIAGE-8984.

## Issues and Related PRs
[CASMTRIAGE-8999](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8999)
[CASMTRIAGE-8984](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8984)

## Testing

### Tested on:

groot bare metal

### Test description:

Tested below scenarios on groot:

**- iSCSI target/ worker node reboot:** During ncn-w001 reboot the corresponding mulipath turned into "faulty" state on the compute node(s). Once the ncn-w001 reboot is complete the path is recovered and state is back to "active" state. No _"LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN"_ messages seen on the compute nodes.
**-  iSCSI target/ worker node rebuild:** During ncn-w002  rebuild the corresponding mulipath turned into "faulty" state on the compute node(s). Once the ncn-w002 rebuild is complete the path is recovered and state is back to "active" state. No _"LUN assignments on this target have changed. The Linux SCSI layer does not automatically remap LUN"_ messages seen on the compute nodes.

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

